### PR TITLE
notice init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-advisors-vector-store'
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-pgvector'
+	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.0'// json to DTO
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/festival/everyday/core/domain/Interest.java
+++ b/src/main/java/com/festival/everyday/core/domain/Interest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 축제 -> 업체 관심 보내기
- * SIGNAL 은 예약어였습니다.... INTEREST로 돌아가겠습니다 ...
+ * SIGNAL 은 예약어였습니다.... INTEREST 로 돌아가겠습니다 ...
  */
 
 @Entity

--- a/src/main/java/com/festival/everyday/core/domain/Review.java
+++ b/src/main/java/com/festival/everyday/core/domain/Review.java
@@ -27,10 +27,16 @@ public class Review {
     @Column(name = "review_content")
     private String content;
 
+    /**
+     * festival, company, labor
+     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private User sender;
 
+    /**
+     * festival, company
+     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id")
     private User receiver;

--- a/src/main/java/com/festival/everyday/core/domain/application/Application.java
+++ b/src/main/java/com/festival/everyday/core/domain/application/Application.java
@@ -36,7 +36,7 @@ public class Application {
     private Festival festival;
 
     @OneToMany(mappedBy = "application", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ExtraQuestion> questions = new ArrayList<>();
+    private List<ExtraQuestion> extraQuestions = new ArrayList<>();
 
     @OneToMany(mappedBy = "application", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Answer> answers = new ArrayList<>();
@@ -55,13 +55,13 @@ public class Application {
      * 질문/답변을 등록하고 제거하는 메서드입니다.
      * 해당 메서드들은 주인 엔티티 (답변, 추가질문 등) 에서만 호출 가능하빈다.
      */
-    public void addQuestion(ExtraQuestion extraQuestion) {
-        questions.add(extraQuestion);
+    public void addExtraQuestion(ExtraQuestion extraQuestion) {
+        extraQuestions.add(extraQuestion);
         extraQuestion.changeApplication(this);
     }
 
-    public void removeQuestion(ExtraQuestion extraQuestion) {
-        questions.remove(extraQuestion);
+    public void removeExtraQuestion(ExtraQuestion extraQuestion) {
+        extraQuestions.remove(extraQuestion);
         extraQuestion.changeApplication(null);
     }
 

--- a/src/main/java/com/festival/everyday/core/domain/favorite/Favorite.java
+++ b/src/main/java/com/festival/everyday/core/domain/favorite/Favorite.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name ="favorite")
-@NoArgsConstructor
 public class Favorite {
 
     @Id @GeneratedValue

--- a/src/main/java/com/festival/everyday/core/domain/notice/CompanyAppliedPayload.java
+++ b/src/main/java/com/festival/everyday/core/domain/notice/CompanyAppliedPayload.java
@@ -1,0 +1,5 @@
+package com.festival.everyday.core.domain.notice;
+
+public class CompanyAppliedPayload implements NoticePayload {
+    private Interested interested;
+}

--- a/src/main/java/com/festival/everyday/core/domain/notice/FestivalDuePayload.java
+++ b/src/main/java/com/festival/everyday/core/domain/notice/FestivalDuePayload.java
@@ -1,0 +1,5 @@
+package com.festival.everyday.core.domain.notice;
+
+public class FestivalDuePayload implements NoticePayload {
+    private int daysLeft;
+}

--- a/src/main/java/com/festival/everyday/core/domain/notice/Interested.java
+++ b/src/main/java/com/festival/everyday/core/domain/notice/Interested.java
@@ -1,0 +1,5 @@
+package com.festival.everyday.core.domain.notice;
+
+public enum Interested {
+    INTERESTED, NOT_INTERESTED
+}

--- a/src/main/java/com/festival/everyday/core/domain/notice/Notice.java
+++ b/src/main/java/com/festival/everyday/core/domain/notice/Notice.java
@@ -1,0 +1,45 @@
+package com.festival.everyday.core.domain.notice;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notice")
+public class Notice {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "notice_id")
+    private Long id;
+
+    @Column(name = "sender_id")
+    private Long senderId;
+
+    @Column(name = "sender_name")
+    private String senderName;
+
+    @Column(name = "receiver_id")
+    private Long receiverId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notice_type")
+    private NoticeType type;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    /**
+     * 알람 종류에 맞춰 JSON 이 payload 로 변환됩니다.
+     */
+    @Type(JsonType.class)
+    @Column(columnDefinition = "json", name = "data")
+    private NoticePayload data;
+}

--- a/src/main/java/com/festival/everyday/core/domain/notice/NoticePayload.java
+++ b/src/main/java/com/festival/everyday/core/domain/notice/NoticePayload.java
@@ -1,0 +1,13 @@
+package com.festival.everyday.core.domain.notice;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = FestivalDuePayload.class, name = "FESTIVAL_DUE"),
+        @JsonSubTypes.Type(value = CompanyAppliedPayload.class, name = "COMPANY_APPLIED")
+})
+public interface NoticePayload {
+
+}

--- a/src/main/java/com/festival/everyday/core/domain/notice/NoticeType.java
+++ b/src/main/java/com/festival/everyday/core/domain/notice/NoticeType.java
@@ -1,0 +1,5 @@
+package com.festival.everyday.core.domain.notice;
+
+public enum NoticeType {
+    FESTIVAL_DEAD, COMPANY_APPLIED, LABOR_APPLIED, APPLY_DECISION, FESTIVAL_DUE, FESTIVAL_INTEREST
+}

--- a/src/main/java/com/festival/everyday/core/domain/recruit/ExtraQuestion.java
+++ b/src/main/java/com/festival/everyday/core/domain/recruit/ExtraQuestion.java
@@ -39,7 +39,7 @@ public class ExtraQuestion {
     public static ExtraQuestion of(String content, Application application) {
         ExtraQuestion extraQuestion = new ExtraQuestion();
         extraQuestion.content = content;
-        application.addQuestion(extraQuestion);
+        application.addExtraQuestion(extraQuestion);
         return extraQuestion;
     }
     /**

--- a/src/main/java/com/festival/everyday/core/domain/user/User.java
+++ b/src/main/java/com/festival/everyday/core/domain/user/User.java
@@ -47,7 +47,7 @@ public abstract class User {
     @OneToMany(mappedBy = "user")
     private List<Application> applications = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "sender")
     private List<Favorite> favorites = new ArrayList<>();
 
     public void uploadImage(Image image) {

--- a/src/main/java/com/festival/everyday/core/repository/FestivalRepository.java
+++ b/src/main/java/com/festival/everyday/core/repository/FestivalRepository.java
@@ -1,0 +1,4 @@
+package com.festival.everyday.core.repository;
+
+public class FestivalRepository {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,8 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 50
+        jdbc:
+          batch_size: 100
 
 
 logging:


### PR DESCRIPTION
알림 도메인을 생성했습니다.

연관 관계를 설정하지 않고, 쿼리를 사용하여 조회하도록 하였습니다.

필드  data 는 다형성을 사용하여 구현하였습니다.

FESTIVAL_DUE, COMPANY_APPLIED만 각각 필요한 필드가 달라 별도로 사용하였고
그 이외의 알림은 data에 json을 저장하지 않습니다.

기본 환경설정 코드이므로 임의로 pull 하겠습니다.

필요에 따라 각자 메서드를 구현해서 사용하세요